### PR TITLE
Correct README to use mtg-deck and not mtg-deckname

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a plugin to manage your Magic: The Gathering card collections and decks 
 
 ## Decklists
 
-Using the `mtg-decklist` syntax hint in any Markdown file, you can define your decklists as follows:
+Using the `mtg-deck` syntax hint in any Markdown file, you can define your decklists as follows:
 
 ```mtgdeck
 4 Delver of Secrets // Insectile Aberration

--- a/main.ts
+++ b/main.ts
@@ -148,7 +148,7 @@ class ObsidianPluginMtgSettingsTab extends PluginSettingTab {
 			.addText((text) =>
 				text
 					.setPlaceholder("Count")
-					.setValue(this.plugin.settings.collection.nameColumn)
+					.setValue(this.plugin.settings.collection.countColumn)
 					.onChange(async (value) => {
 						this.plugin.settings.collection.countColumn = value;
 						await this.plugin.saveSettings();


### PR DESCRIPTION
This PR :
- fixes the display of the configured Count Column name in the settings
- updates README to correctly document the markdown hint as `mtg-deck` and not `mtg-decklist`