### PR TITLE
Allow cards to render past the box and makes default card size much bigger

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -73,7 +73,7 @@ span.comment {
 }
 
 .card-image {
-	height: 180px;
+	height: 400px;
 }
 
 .buylist-container {
@@ -122,4 +122,9 @@ span.comment {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+}
+
+.markdown-source-view.mod-cm6 .cm-preview-code-block:has(> .block-language-mtg-deck) {
+    overflow: visible;
+    contain: initial !important;
 }


### PR DESCRIPTION
Add code to allow card overflow if it's past the render box. Also made card size bigger.

Currently, if you mouse over a card at the bottom of your deck, it will get cut off as it goes past the render box (I don't know the actual term for it).

This patch fixes that issue.

I also upped the card size to 400px. It was so small it was unreadable for me before. I'll make another PR to add a setting to let users change it.