### PR TITLE
Support sets and collector numbers

### DIFF
--- a/src/renderer.spec.ts
+++ b/src/renderer.spec.ts
@@ -3,7 +3,7 @@ import { renderDecklist } from "./renderer";
 import { JSDOM } from "jsdom";
 import { ObsidianPluginMtgSettings } from "./settings";
 import { EXAMPLE_DECKLIST_CARD_DATA } from "../jest/fixtures/scryfall-data";
-import { CardData } from "./scryfall";
+import { CardIdentifier, CardData } from "./scryfall";
 import {
 	EXAMPLE_COLLECTION,
 	EXAMPLE_DECK_1,
@@ -15,7 +15,7 @@ const dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
 const doc = dom.window.document;
 
 const fakeFetcher = (
-	distinctCardNames: string[]
+	distinctCards: CardIdentifier[]
 ): Promise<Record<string, CardData>> =>
 	new Promise((resolve, reject) => {
 		resolve(EXAMPLE_DECKLIST_CARD_DATA as Record<string, CardData>);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -24,7 +24,7 @@ interface Line {
 	text?: string;
 }
 
-const lineMatchRE = /^(\d+)\s+(.*?)(\s+\(([A-Za-z0-9]{3})\)\s+(\d+))?$/;
+const lineMatchRE = /^(\d+)\s+(.*?)(\s+\(([A-Za-z0-9]{3})\)\s+0*(\d+))?$/;
 const blankLineRE = /^\s+$/;
 const headingMatchRE = new RegExp("^[^[0-9|" + COMMENT_DELIMITER + "]");
 

--- a/src/scryfall.spec.ts
+++ b/src/scryfall.spec.ts
@@ -35,7 +35,11 @@ describe("Scryfall", () => {
 				});
 			}
 			const data = await getMultipleCardData(
-				["Delver of Secrets", "Ledger Shredder", "Dark Ritual"],
+				[
+					{ name: "Delver of Secrets" },
+					{ name: "Ledger Shredder" },
+					{ name: "Dark Ritual" },
+				],
 				httpReq
 			);
 			expect(data).toEqual(EXAMPLE_MULTI_CARD_RESPONSE);

--- a/src/scryfall.ts
+++ b/src/scryfall.ts
@@ -2,6 +2,15 @@ import { promiseWrappedRequest } from "./http";
 
 const querystring = require("querystring");
 
+export type CardIdentifier =
+	| {
+			name: string;
+	  }
+	| {
+			set: string;
+			collector_number: string;
+	  };
+
 export interface RequestOptions {
 	url: string;
 	method?: string;
@@ -148,10 +157,10 @@ export const getCardData = async (
 };
 
 export const getMultipleCardData = async (
-	cardNames: string[],
+	cardIdentifiers: CardIdentifier[],
 	request = promiseWrappedRequest
 ): Promise<ScryfallResponse> => {
-	if (cardNames.length === 0) {
+	if (cardIdentifiers.length === 0) {
 		// Return an empty response
 		return new Promise((resolve, reject) => {
 			resolve({
@@ -162,10 +171,6 @@ export const getMultipleCardData = async (
 			} as ScryfallResponse);
 		});
 	}
-
-	const cardIdentifiers = cardNames.map((cardName) => ({
-		name: cardName,
-	}));
 
 	const postData = JSON.stringify({
 		identifiers: cardIdentifiers,


### PR DESCRIPTION
This commit adds support for sets and collector numbers in the `mtg-deck` syntax. If a card has a provided set and collector number, the Scryfall API call uses those instead of the card name.